### PR TITLE
www: update wwwSettings.json file path

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@
 
 <?php
 
-$settings = file_get_contents('/var/www/wwwSettings.json');
+$settings = file_get_contents('wwwSettings.json');
 if($settings == false){
 	die("Cannot open settings file");
 }


### PR DESCRIPTION
removed path to wwwSettings.json for people who do not have the website in /var/www
removing the path all together allows it to just grab it from the local directory.
