### PR TITLE
support for running on Windows. factored out socket_open().

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -1,0 +1,8 @@
+<?php
+
+function getConfig($key, $defaultValue)
+{
+    return isset($GLOBALS[$key]) ? $GLOBALS[$key] : $defaultValue;
+}
+
+?>

--- a/maintenance-panel.php
+++ b/maintenance-panel.php
@@ -25,7 +25,7 @@
 	<li><a href="#advanced-settings"><span>Advanced Settings</span></a></li>
 	<li><a href="#reprogram-arduino"><span>Reprogram Arduino</span></a></li>
 	<!--kinda dirty to have buttons in the ul, but the ul is styled as a nice header by jQuery UI -->
-	<button class="script-status"</button>
+	<button class="script-status"></button>
 </ul>
 <div id="reprogram-arduino">
 	<div class="script-warning ui-widget-content ui-corner-all" style="padding:5px;">

--- a/program_arduino.php
+++ b/program_arduino.php
@@ -16,8 +16,12 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+require_once('socket_open.php');
+
+
 // Set instance root
-$instanceRoot = getcwd();
+$instanceRoot = str_replace("\\", "/", getcwd());
+
 
 // Read config settings
 if(file_exists('config.php')) {
@@ -69,7 +73,8 @@ else{
 <?php
 $sock = open_socket();
 if($sock !== false){
-	socket_write($sock, "programArduino={\"boardType\":\"$boardType\",\"fileName\":\"$instanceRoot/uploads/$fileName\",\"eraseEEPROM\":$eraseEEPROM}", 1024);
+    $cmd = "programArduino={\"boardType\":\"$boardType\",\"fileName\":\"$instanceRoot/uploads/$fileName\",\"eraseEEPROM\":$eraseEEPROM}";
+	socket_write($sock, $cmd, 1024);
 	$avrdudeOutput = socket_read($sock, 4096);
 	socket_close($sock);
 }
@@ -83,25 +88,5 @@ if($sock !== false){
 </div>
 </body>
 </html>
-<?php
-function open_socket()
-{
-	$sock = socket_create(AF_UNIX, SOCK_STREAM, 0);
-	if ($sock === false) {
-		return false;
-	}
-	else{
-		if(socket_connect($sock, "$GLOBALS[scriptPath]/BEERSOCKET")){
-			socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec' => 15, 'usec' => 0));
-			return $sock;
-		}
-		else{
-			echo "Not connected";
-			# echo socket_strerror(socket_last_error($sock));
-			return false;
-		}
-	}
-}
-?>
 
 

--- a/socket_open.php
+++ b/socket_open.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once('configuration.php');
+
+function open_socket()
+{
+    $isWindows = defined('PHP_WINDOWS_VERSION_MAJOR');
+	$useInetSocket = getConfig("useInetSocket", $isWindows);
+	if ($useInetSocket)
+		$sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	else
+	    $sock = socket_create(AF_UNIX, SOCK_STREAM, 0);
+
+	if (!($sock === false))
+	{
+		if(
+			((!$useInetSocket) && socket_connect($sock, "$GLOBALS[scriptPath]/BEERSOCKET"))
+		     || (($useInetSocket) && socket_connect($sock, getConfig("scriptAddress", "localhost"), getConfig("scriptPort",6332))))
+		{
+			socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec' => 15, 'usec' => 0));
+		}
+		else{
+			socket_close($sock);
+			echo "Not connected";
+			if (getConfig('debug', false))
+				echo socket_strerror(socket_last_error($sock));
+		}
+	}
+	return $sock;
+}
+
+
+?>

--- a/socketmessage.php
+++ b/socketmessage.php
@@ -16,6 +16,8 @@
  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+require_once('socket_open.php');
+
 // Read config settings
 if(file_exists('config.php')) {
 	require_once('config.php');
@@ -132,28 +134,5 @@ if($sock !== false){
 			break;
 	}
 	socket_close($sock);
-}
-
-function open_socket()
-{
-	$sock = socket_create(AF_UNIX, SOCK_STREAM, 0);
-	if ($sock === false) {
-		return false;
-	}
-	else{
-		if(socket_connect($sock, "$GLOBALS[scriptPath]/BEERSOCKET")){
-			socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec' => 15, 'usec' => 0));
-			return $sock;
-		}
-		else{
-			echo "Cannot connect to script, please make sure that it is running.\n";
-			echo "If you have set up the CRON job, try clicking the 'Start script' button\n";
-			echo "and wait for CRON to start the python script.\n";
-			echo "If that does not work, check the log files for errors.\n\n";
-			// when debugging, uncomment this:
-			echo "Error message: " . socket_strerror(socket_last_error($sock));
-			return false;
-		}
-	}
 }
 ?>


### PR DESCRIPTION
Windows doesn't have domain sockets, so I've added support to use TCP sockets on Windows, with a configurable override, useInetSocket so this can also be tested on non-windows platforms.

I factored out the socket_open function which was duplicated. 

Finally, avrdude failed with the path generated because of mixed slashed -  like c\arduino-1.0.4\hardware/arduino/tools. Fixed the instance root to use just one type of slash.

I do my primary brewpi development on windows, and I'm sure others will like the opportunity. 
