### PR TITLE
Fixed useradd to create home dir totally empty

### DIFF
--- a/docs/user/source/getting-started/setup-users-permissions.rst
+++ b/docs/user/source/getting-started/setup-users-permissions.rst
@@ -7,7 +7,7 @@ Then, we set the password for the brewpi user with passwd.
 
 .. code-block:: bash
 
-    sudo useradd -m -G www-data dialout brewpi
+    sudo useradd -m -k /dev/null -G www-data dialout brewpi
     sudo passwd brewpi
 
 Now, verify your work:


### PR DESCRIPTION
When used with -m, useradd creates a home directory, BUT it also adds a bunch of .hidden files (.bashrc, etc) by default. Using the -k /dev/null prevents that from happening. 

This is important because git clone can only clone a repository to a COMPLETELY empty dir (a few steps later in the process). If the .hidden files are present, the cloning will fail.
